### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``get_action``

--- a/actions/get_action.yaml
+++ b/actions/get_action.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_action
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_all_domains.yaml
+++ b/actions/get_all_domains.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_all_domains
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_all_droplets.yaml
+++ b/actions/get_all_droplets.yaml
@@ -11,4 +11,4 @@ parameters:
     default: get_all_droplets
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_all_images.yaml
+++ b/actions/get_all_images.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_all_images
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_all_regions.yaml
+++ b/actions/get_all_regions.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_all_regions
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_all_sizes.yaml
+++ b/actions/get_all_sizes.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_all_sizes
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_all_sshkeys.yaml
+++ b/actions/get_all_sshkeys.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_all_sshkeys
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_data.yaml
+++ b/actions/get_data.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_data
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_domain.yaml
+++ b/actions/get_domain.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_domain
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_droplet.yaml
+++ b/actions/get_droplet.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_droplet
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_global_images.yaml
+++ b/actions/get_global_images.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_global_images
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_image.yaml
+++ b/actions/get_image.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_image
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_my_images.yaml
+++ b/actions/get_my_images.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_my_images
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/actions/get_ssh_key.yaml
+++ b/actions/get_ssh_key.yaml
@@ -7,4 +7,4 @@ parameters:
     default: get_ssh_key
     immutable: true
     type: string
-runner_type: run-python
+runner_type: python-script

--- a/etc/do_metagenerator.py
+++ b/etc/do_metagenerator.py
@@ -37,7 +37,7 @@ def generate_meta(actions, pack):
                     "default": action
                 }
             },
-            "runner_type": "run-python",
+            "runner_type": "python-script",
             "description": "",
             "enabled": True,
             "entry_point": "do.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: digitalocean
 name : Digital Ocean
 description : st2 content pack containing Digital Ocean integration.
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.