### PR TITLE
Fix JSON serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.3
+
+- Fix JSON serialization with recent upstream digitalocean package changes
+
 # 0.3.2
 
 - Version bump to fix tagging issues

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -15,6 +15,9 @@ class BaseAction(Action):
         # digitalocean.baseapi.BaseAPI has a field named _log that doesn't like to be serialized
         if "_log" in obj_dict:
             del obj_dict['_log']
+        # digitalocean.baseapi.BaseAPI has a field named _log that doesn't like to be serialized
+        if "_session" in obj_dict:
+            del obj_dict['_session']
         return obj_dict
 
     def do_action(self, cls, action, **kwargs):

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -12,12 +12,10 @@ class BaseAction(Action):
     @staticmethod
     def digitalocean_obj_to_dict(obj):
         obj_dict = obj.__dict__
-        # digitalocean.baseapi.BaseAPI has a field named _log that doesn't like to be serialized
-        if "_log" in obj_dict:
-            del obj_dict['_log']
-        # digitalocean.baseapi.BaseAPI has a field named _log that doesn't like to be serialized
-        if "_session" in obj_dict:
-            del obj_dict['_session']
+        # digitalocean.baseapi.BaseAPI has fields named _log and _session that don't like to be
+        # serialized
+        obj_dict.pop('_log', None)
+        obj_dict.pop('_session', None)
         return obj_dict
 
     def do_action(self, cls, action, **kwargs):

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: digitalocean
 name: Digital Ocean
 description: Digital Ocean integration.
-version: 0.3.2
+version: 0.3.3
 python_versions:
   - "2"
   - "3"

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -11,6 +11,7 @@ import mock
 class TestLibAction(DigitalOceanBaseActionTestCase):
     __test__ = True
     action_cls = DigitalOceanManager
+    maxDiff = None
 
     def test_init(self):
         action = self.get_action_instance(self.config_good)

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -32,7 +32,16 @@ class TestLibAction(DigitalOceanBaseActionTestCase):
         expected = self.droplet_dict
         droplet = self.dict_to_droplet(expected)
         result = BaseAction.digitalocean_obj_to_dict(droplet)
-        self.assertEqual(result, expected)
+        # The result may have an extra _session key, so make sure that result
+        # is a subset of expected, see:
+        # https://circleci.com/gh/StackStorm-Exchange/stackstorm-digitalocean/195
+        # Unfortunately this method is not very transparent if the assertion
+        # fails - there was a assertDictContainsSubset assertion, but it was
+        # deprecated in Python 3.2 and presumably removed in Python 3.3
+        # The hope here is that this assertion is properly relaxed (compared
+        # to strict/simple equality), so it will not break very often.
+        # See https://stackoverflow.com/a/9323769/6461688
+        self.assertTrue(all(item in result.items() for item in expected.items()))
 
     def test_digitalocean_obj_to_dict__log_removed(self):
         expected = self.droplet_dict
@@ -40,13 +49,13 @@ class TestLibAction(DigitalOceanBaseActionTestCase):
         droplet_copy['_log'] = "test log removed"
         droplet = self.dict_to_droplet(droplet_copy)
         result = BaseAction.digitalocean_obj_to_dict(droplet)
-        self.assertEqual(result, expected)
+        self.assertTrue(all(item in result.items() for item in expected.items()))
 
     def test_digitalocean_obj_to_dict_json(self):
         expected = self.droplet_dict
         droplet = self.dict_to_droplet(expected)
         result = BaseAction.digitalocean_obj_to_dict(droplet)
-        self.assertEqual(result, expected)
+        self.assertTrue(all(item in result.items() for item in expected.items()))
 
         json_str = json.dumps(droplet, default=BaseAction.digitalocean_obj_to_dict)
         json_result = json.loads(json_str)

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -32,16 +32,7 @@ class TestLibAction(DigitalOceanBaseActionTestCase):
         expected = self.droplet_dict
         droplet = self.dict_to_droplet(expected)
         result = BaseAction.digitalocean_obj_to_dict(droplet)
-        # The result may have an extra _session key, so make sure that result
-        # is a subset of expected, see:
-        # https://circleci.com/gh/StackStorm-Exchange/stackstorm-digitalocean/195
-        # Unfortunately this method is not very transparent if the assertion
-        # fails - there was a assertDictContainsSubset assertion, but it was
-        # deprecated in Python 3.2 and presumably removed in Python 3.3
-        # The hope here is that this assertion is properly relaxed (compared
-        # to strict/simple equality), so it will not break very often.
-        # See https://stackoverflow.com/a/9323769/6461688
-        self.assertTrue(all(item in result.items() for item in expected.items()))
+        self.assertEqual(result, expected)
 
     def test_digitalocean_obj_to_dict__log_removed(self):
         expected = self.droplet_dict
@@ -49,13 +40,13 @@ class TestLibAction(DigitalOceanBaseActionTestCase):
         droplet_copy['_log'] = "test log removed"
         droplet = self.dict_to_droplet(droplet_copy)
         result = BaseAction.digitalocean_obj_to_dict(droplet)
-        self.assertTrue(all(item in result.items() for item in expected.items()))
+        self.assertEqual(result, expected)
 
     def test_digitalocean_obj_to_dict_json(self):
         expected = self.droplet_dict
         droplet = self.dict_to_droplet(expected)
         result = BaseAction.digitalocean_obj_to_dict(droplet)
-        self.assertTrue(all(item in result.items() for item in expected.items()))
+        self.assertEqual(result, expected)
 
         json_str = json.dumps(droplet, default=BaseAction.digitalocean_obj_to_dict)
         json_result = json.loads(json_str)


### PR DESCRIPTION
An [upstream change](https://github.com/koalalorenzo/python-digitalocean/pull/268) in the [digitalocean](https://github.com/koalalorenzo/python-digitalocean) project added a `requests.session.Session` object in the `_session` key that [prevents JSON serialization](https://circleci.com/gh/StackStorm-Exchange/stackstorm-digitalocean/195):

```
======================================================================
3) FAIL: test_digitalocean_obj_to_dict_json (test_do.TestLibAction)
----------------------------------------------------------------------
   Traceback (most recent call last):
    tests/test_do.py line 49 in test_digitalocean_obj_to_dict_json
      self.assertEqual(result, expected)
   AssertionError: {...}
   - {'_session': <requests.sessions.Session object at 0x7f12c3eb81d0>,
   -  'action_ids': [],
   ? ^
   
   + {'action_ids': [],
   ? ^
   
      'backup_ids': [],
      'backups': False,
      ...
```

This PR removes the `_session` key/value from the dictionary before attempting to serialize it to JSON.

I originally changed the test assertion to test that the expected dictionary is a subset of the result dictionary, but that ended up not being necessary. I'm keeping that commit, however, in case we need it in the future. You should not see that in the PR diff. And for reference, [this error](https://circleci.com/gh/StackStorm-Exchange/stackstorm-digitalocean/202) is from the code that checked for dictionary subset.

Additionally, I set `maxDiff = None` so that all differences are printed out when the test assertions fail. This should ease troubleshooting around this issue in the future, and should have no effect whatsoever on the speed or verbosity of any passing builds.

There was [a similar PR](https://github.com/koalalorenzo/python-digitalocean/pull/239) to the upstream project to remove the `_log` object before pickling the object, but unfortunately that doesn't include the `_session` attribute. I believe that [this code](https://github.com/StackStorm-Exchange/stackstorm-digitalocean/blob/87a674c5d3c15395da33f16983c2fe40d0151fe3/actions/lib/action.py#L16) is now obsolete, but I'll keep it in for now just in case.
